### PR TITLE
map role id instead of role index

### DIFF
--- a/classes/local/converter.php
+++ b/classes/local/converter.php
@@ -51,18 +51,11 @@ class converter {
          *
          * Source https://www.imsglobal.org/oneroster-v11-final-specification#_Toc480452032.
          */
-        
-         // Important Note: Based on IMS Specification for OneRoster date times should be formatted in UTL
-        // so this conversion is imvalid 
-
-        // $datetime = DateTime::createFromFormat(
-        //     'Y-m-d',
-        //     $date,
-        //     new DateTimeZone('UTC')
-        // );
-
-        $datetime = new DateTime($date);
-        
+        $datetime = DateTime::createFromFormat(
+            'Y-m-d',
+            $date,
+            new DateTimeZone('UTC')
+        );
         $datetime->setTime(0, 0, 0, 0);
 
         return $datetime->getTimestamp();

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -530,6 +530,7 @@ EOF;
 
         // Fetch the user representation for this entity.
         $remoteuser = $entity->get_user_data();
+        $remoteuser->mnethostid = $CFG->mnet_localhost_id;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 

--- a/settings.php
+++ b/settings.php
@@ -233,13 +233,6 @@ if ($ADMIN->fulltree) {
             $roleNames
         );
 
-    // $courseroles = array_merge(
-    //     [
-    //         -1 => get_string('settings_notmapped', 'enrol_oneroster'),
-    //     ],
-    //     role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
-    // );
-
     // Mapping for the 'student' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'student', $allroles, $courseroles, 'student');
 

--- a/settings.php
+++ b/settings.php
@@ -180,16 +180,18 @@ if ($ADMIN->fulltree) {
         ''
     ));
 
+    $fields = [
+        'sourcedId' => 'sourcedId',
+        'classCode' => 'classCode'
+    ];
+
     $settings->add(
         new admin_setting_configselect(
             'enrol_oneroster/shortname_attribute',
             get_string('settings_shortname_attribute', 'enrol_oneroster'),
             get_string('settings_shortname_attribute_desc', 'enrol_oneroster'),
             'sourcedId',
-            [
-                'sourcedId' => 'sourcedId',
-                'classCode' => 'classCode'
-            ]
+            $fields
         )
     );
 
@@ -215,16 +217,28 @@ if ($ADMIN->fulltree) {
             -1 => 'notmapped',
         ],
         array_map(function($role) {
-
             return $role->shortname;
         }, get_all_roles(null))
     );
-    $courseroles = array_merge(
-        [
-            -1 => get_string('settings_notmapped', 'enrol_oneroster'),
-        ],
-        role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
-    );
+
+    // important change:use role id instead of role index which may cause a lot of errors 
+    // when administrators are changing sort order.
+    $roles = get_all_roles(\context_course::instance(SITEID));
+    $roleNames = role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true);
+    
+    $courseroles =
+        [ '0' => get_string('settings_notmapped', 'enrol_oneroster') ] +
+        array_combine(
+            array_map(function($v){ return strval($v->id); }, $roles),
+            $roleNames
+        );
+
+    // $courseroles = array_merge(
+    //     [
+    //         -1 => get_string('settings_notmapped', 'enrol_oneroster'),
+    //     ],
+    //     role_get_names(\context_course::instance(SITEID), ROLENAME_ALIAS, true)
+    // );
 
     // Mapping for the 'student' role.
     \enrol_oneroster\settings::add_role_mapping($settings, 'student', $allroles, $courseroles, 'student');

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022072101;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2022072102;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2022-07-21';
+$plugin->release = '2022-09-19';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This PR uses role id for mapping moodle user role. This change is very important to avoid errors while syncing data. Syncronization process uses role identifiers but role mapping used role sort index. So, if an admin changes sort order, this action will affect synchronization order with unhandled errors.