### PR TITLE
use user mapping while updating an existing user

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -595,9 +595,14 @@ EOF;
      */
     protected function update_existing_user(user_representation $entity, stdClass $remoteuser): stdClass {
         global $DB;
-
-        $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
-
+        // try to get user mapping
+        $mapping = $this->get_user_mapping($remoteuser->idnumber);
+        if ($mapping) {
+            $localuser = $DB->get_record('user', ['id' => $mapping]);
+        } else {
+            // No mapping found, try to get user by idnumber
+            $localuser = $DB->get_record('user', ['idnumber' => $remoteuser->idnumber]);
+        }
         // The user exists, user_update_user works on user 'id', so fill that in.
         $remoteuser->id = $localuser->id;
 

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023110300;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024041000;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2022-09-19';


### PR DESCRIPTION
This PR updates `update_existing_user()` operation to use user mapping for finding the user identifier that is going to be updated. If the user mapping is missing, the update operation will try to query the database by using the `idnumber` attribute of the given user.