### PR TITLE
sync only student and teacher accounts

### DIFF
--- a/classes/local/entities/class_entity.php
+++ b/classes/local/entities/class_entity.php
@@ -27,6 +27,8 @@ namespace enrol_oneroster\local\entities;
 use coding_exception;
 use enrol_oneroster\local\converter;
 use enrol_oneroster\local\collections\enrollments as enrollments_collection;
+use enrol_oneroster\local\collections\students_for_class as students_collection;
+use enrol_oneroster\local\collections\teachers_for_class as teachers_collection;
 use enrol_oneroster\local\interfaces\container as container_interface;
 use enrol_oneroster\local\interfaces\course_representation;
 use enrol_oneroster\local\interfaces\user_representation;
@@ -204,5 +206,49 @@ class class_entity extends entity implements course_representation {
 
         $filter->add_filter('class', $this->get('sourcedId'));
         return $this->container->get_collection_factory()->get_enrollments($params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all students in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  students_collection
+     */
+    public function get_students(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): students_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_students_for_class($class, $params, $filter, $recordfilter);
+    }
+
+    /**
+     * Fetch all teachers in the Class.
+     *
+     * @param   array $params
+     * @param   filter|null $filter
+     * @param   callable $recordfilter
+     * @return  teachers_collection
+     */
+    public function get_teachers(
+        array $params = [],
+        ?filter $filter = null,
+        ?callable $recordfilter = null
+
+    ): teachers_collection {
+        if ($filter === null) {
+            $filter = $this->container->get_filter_instance();
+        }
+        //$filter->add_filter('class', $this->get('sourcedId'));
+        $class = $this;
+        return $this->container->get_collection_factory()->get_teachers_for_class($class, $params, $filter, $recordfilter);
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
 $plugin->release = '2024-09-17';


### PR DESCRIPTION
This PR implements a breaking change that affects user synchronization process. Student and teacher accounts are synchronized based on the classes being processed. 
This operation seems to be important when we are trying to synchronize a collection of classes where the active students and teachers are a small subset of the existing users.  