### PR TITLE
Catch error and continue

### DIFF
--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091801;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-17';
+$plugin->release = '2024-09-19';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This PR changes sync process and catches error while syncing a school, inserting a user etc in order to allow synchronization process to finish even if some data are invalid. This operation is very important when dealing with large organization with hundreds of courses, classes, or user enrollments.