### PR TITLE
enable disable caching

### DIFF
--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -77,4 +77,10 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function get_enrolment_cache(): cache;
+    /**
+     * Purge entity cache.
+     *
+     * @return  cache
+     */
+    abstract public function purge_cache();
 }

--- a/classes/local/factories/entity_factory.php
+++ b/classes/local/factories/entity_factory.php
@@ -73,6 +73,12 @@ class entity_factory extends abstract_factory implements entity_factory_interfac
      * @return  stdClass|null The data stored in the cache
      */
     protected function fetch_from_cache(string $entitytype, string $id, ?filter $filter = null): ?stdClass {
+        
+        if (empty($CFG->cachetype)) {
+            // Caching is disabled.
+            return null;
+        }
+
         if ($filter !== null) {
             // It is not possible to use the cache when a filter is applied.
             return null;

--- a/classes/local/factories/entity_factory.php
+++ b/classes/local/factories/entity_factory.php
@@ -74,11 +74,6 @@ class entity_factory extends abstract_factory implements entity_factory_interfac
      */
     protected function fetch_from_cache(string $entitytype, string $id, ?filter $filter = null): ?stdClass {
         
-        if (empty($CFG->cachetype)) {
-            // Caching is disabled.
-            return null;
-        }
-
         if ($filter !== null) {
             // It is not possible to use the cache when a filter is applied.
             return null;

--- a/classes/local/oneroster_client.php
+++ b/classes/local/oneroster_client.php
@@ -191,6 +191,12 @@ trait oneroster_client {
      */
     public function synchronise(?int $onlysincetime = null): void {
         if (class_implements($this, rostering_client::class)) {
+            $caching = get_config('enrol_oneroster', 'oneroster_caching');
+            // if caching is disabled, purge the cache before start
+            if ($caching != '1') {
+                // purge cache and let process to create new cache items
+                $this->get_container()->get_cache_factory()->purge_cache();
+            }
             $this->sync_roster($onlysincetime);
         }
     }

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -89,4 +89,17 @@ class cache_factory extends parent_cache_factory {
     public function get_enrolment_cache(): cache {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
+
+    /**
+     * Purge the cache.
+     */
+    public function purge_cache() {       
+        $this->get_org_cache()->purge();
+        $this->get_academic_session_cache()->purge();
+        $this->get_class_cache()->purge();
+        $this->get_course_cache()->purge();
+        $this->get_user_cache()->purge();
+        $this->get_enrolment_cache()->purge();
+    }
+
 }

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -80,3 +80,5 @@ $string['test_oneroster_connection'] = 'Test One Roster Connection';
 $string['fullsync'] = 'Full sync of One Roster';
 $string['settings_datasync_academic_session'] = 'Select academic session';
 $string['settings_datasync_academic_session_desc'] = 'Select the academic session for synchronizing classes and student enrollments.';
+$string['settings_connection_oneroster_caching'] = 'Caching';
+$string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';

--- a/settings.php
+++ b/settings.php
@@ -118,6 +118,16 @@ if ($ADMIN->fulltree) {
         4
     ));
 
+    $yesno = array(get_string('no'), get_string('yes'));
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_caching',
+        get_string('settings_connection_oneroster_caching', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_caching_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
+
     // Test connection.
     $settings->add(new admin_setting_heading(
         'enrol_oneroster/testconnection',

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024092002;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-09-19';
+$plugin->release = '2024-09-20';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This PR closes #10 and changes the usage of caching across different sync processes. If caching option is disabled OneRoster cache is being purged before starting a sync process.