### PR TITLE
 Enable caching of OneRoster classes for validatiing updates

### DIFF
--- a/classes/local/factories/cache_factory.php
+++ b/classes/local/factories/cache_factory.php
@@ -83,4 +83,6 @@ abstract class cache_factory extends abstract_factory implements cache_factory_i
      * @return  cache
      */
     abstract public function purge_cache();
+
+    abstract public function get_class_snapshot_cache(): cache;
 }

--- a/classes/local/v1p1/factories/cache_factory.php
+++ b/classes/local/v1p1/factories/cache_factory.php
@@ -90,6 +90,10 @@ class cache_factory extends parent_cache_factory {
         return cache::make('enrol_oneroster', 'v1p1_remote_enrolments');
     }
 
+    public function get_class_snapshot_cache(): cache {
+        return cache::make('enrol_oneroster', 'v1p1_remote_class_snapshots');
+    }
+
     /**
      * Purge the cache.
      */
@@ -100,6 +104,7 @@ class cache_factory extends parent_cache_factory {
         $this->get_course_cache()->purge();
         $this->get_user_cache()->purge();
         $this->get_enrolment_cache()->purge();
+        $this->get_class_snapshot_cache()->purge();
     }
 
 }

--- a/db/caches.php
+++ b/db/caches.php
@@ -68,4 +68,11 @@ $definitions = [
         'staticacceleration' => true,
         'staticaccelerationsize' => 1000,
     ],
+    'v1p1_remote_class_snapshots' => [
+        'mode' => cache_store::MODE_APPLICATION,
+        'simplekeys' => false,
+        'simpledata' => true,
+        'staticacceleration' => true,
+        'staticaccelerationsize' => 1000,
+    ],
 ];

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102001;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024102305;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-20';
+$plugin->release = '2024-10-23';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This PR implements a new cache storage for OneRoster classes. This storage holds information about classes being synced. The synchronization process searches cache items in order to identify if a class has been modified after last synced.