### PR TITLE
add course groups

### DIFF
--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -175,4 +175,16 @@ class enrollment extends entity implements enrollment_representation {
         // A user is enrolled in a class, which we use as a representation of a Moodle course.
         return $this->get_class_entity();
     }
+
+    public function get_enrolment_term(): ?stdClass {
+        $metadata = $this->get('metadata');
+        if (empty($metadata)) {
+            return null;
+        }
+        if (is_string($metadata->term)) {
+            return $this->container->get_entity_factory()->fetch_term_by_id($metadata->term);
+        }
+        return null;
+    }
+
 }

--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -176,7 +176,7 @@ class enrollment extends entity implements enrollment_representation {
         return $this->get_class_entity();
     }
 
-    public function get_enrolment_term(): ?stdClass {
+    public function get_enrolment_term() {
         $metadata = $this->get('metadata');
         if (empty($metadata)) {
             return null;

--- a/classes/local/interfaces/enrollment_representation.php
+++ b/classes/local/interfaces/enrollment_representation.php
@@ -63,5 +63,5 @@ interface enrollment_representation {
      *
      * @return  stdClass
      */
-    public function get_enrolment_term(): ?stdClass;
+    public function get_enrolment_term();
 }

--- a/classes/local/interfaces/enrollment_representation.php
+++ b/classes/local/interfaces/enrollment_representation.php
@@ -57,4 +57,11 @@ interface enrollment_representation {
      * @return  course_representation
      */
     public function get_course_representation(): course_representation;
+
+    /**
+     * Get the term of the enrollment, if available.
+     *
+     * @return  stdClass
+     */
+    public function get_enrolment_term(): ?stdClass;
 }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -543,7 +543,7 @@ EOF;
     /**
      * Create course group using the given academic session
      * @param \stdClass $course
-     * @param \stdClass $term
+     * @param term_entity $term
      * @return \stdClass
      */
     protected function create_course_group_from_term(stdClass $course, term_entity $term): stdClass {

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -55,6 +55,15 @@ use moodle_url;
 use progress_trace;
 use stdClass;
 
+function uuid_make($string){
+    return substr($string, 0, 8 ) .'-'.
+    substr($string, 8, 4) .'-'.
+    substr($string, 12, 4) .'-'.
+    substr($string, 16, 4) .'-'.
+    substr($string, 20);
+  }
+
+
 /**
  * One Roster v1p1 client.
  *
@@ -328,6 +337,8 @@ EOF;
         $classes = $school->get_classes([], $classfilter);
         // get class snapshot cache
         $snapshots = $this->container->get_cache_factory()->get_class_snapshot_cache();
+        // use class groups
+        $use_class_groups = get_config('enrol_oneroster', 'oneroster_sync_groups');
         foreach ($classes as $class) {
             // get class snapshot
             $sourcedid = $class->get('sourcedId');
@@ -363,7 +374,6 @@ EOF;
 
             // update or create class
             $localcourse = $this->update_or_create_course($class);
-
             $this->get_trace()->output(
                 sprintf(
                     "Getting existing enrollments for course '%s' with id %s",
@@ -430,9 +440,6 @@ EOF;
                         $error_count++;
                         $this->get_trace()->output("Error synchronising student '{$student->get('username')}'", 4);
                         $this->get_trace()->output("Error '{$e->getMessage()}'", 4);
-                        // if ($CFG->debugdeveloper) { // DEBUG_DEVELOPER
-                        //     $this->get_trace()->output($e->getTraceAsString(), 4);
-                        // }
                     }
                 }
 
@@ -451,6 +458,24 @@ EOF;
                 $this->get_trace()->output(sprintf("Fetching enrolments data for '%s'", $class->get('title')), 5);
                 foreach ($class->get_enrollments() as $enrollment) {
                     $this->update_or_create_enrolment($enrollment);
+                    // feature: course group management
+                    // description: add user to group
+                    if ($use_class_groups) {
+                        // add user to group using the enrollment term, if available
+                        $enrolment_term = $enrollment->get_enrolment_term();
+                        if ($enrolment_term) {
+                            // try to find if the current course has a group associated with the term
+                            $course_group = $this->create_course_group_from_term($localcourse, $enrolment_term);
+                            // get remote user
+                            $userentity = $enrollment->get_user_entity();
+                            // find local user
+                            $localuserid = $this->get_user_mapping_for_user($userentity);
+                            if ($localuserid) {
+                                // add group membership
+                                groups_add_member($course_group, $localuserid, 'enrol_oneroster');
+                            }
+                        }
+                    }
                 }
             }
             foreach ($this->existingroleassignments as $instanceid => $ra) {
@@ -483,7 +508,13 @@ EOF;
                             $localuser->username,
                             $localcourse->id
                         ), 5);
-
+                        // feature: course group management
+                        // description: remove user from groups
+                        if (is_array($localcourse->groups)) {
+                            foreach ($localcourse->groups as $group) {
+                                groups_remove_member($group, $userid);
+                            }
+                        }
                         $this->get_plugin_instance()->unenrol_user(
                             $instance,
                             $userid
@@ -505,6 +536,43 @@ EOF;
             // and update snapshot cache
             $snapshots->set($data->sourcedId, $data);
         }
+    }
+
+    /**
+     * Create course group using the given academic session
+     * @param \stdClass $course
+     * @param \stdClass $term
+     * @return \stdClass
+     */
+    protected function create_course_group_from_term(stdClass $course, stdClass $term): stdClass {
+        global $DB;
+        // if course groups are not enabled
+        if (!is_array($course->groups)) {
+            // get groups
+            $course->groups = $DB->get_records('groups', ['courseid' => $course->id]);
+        }
+        // generate group idnumber from course->idnumber and term->sourcedid
+        $id = array('class' => $course->idnumber, 'term' => $term->sourcedid);
+        $idnumber = uuid_make(md5(json_encode($id)));
+        // try to find a course group with the same idnumber
+        $found = array_filter($course->groups, function($group) use ($idnumber) {
+            return $group->idnumber == $idnumber;
+        });
+        // if group is found, return it
+        if (count($found) > 0) {
+            return $found[0];
+        }
+        // otherwise, create a new group
+        $group = new stdClass();
+        $group->courseid = $course->id;
+        $group->name = $term->name;
+        $group->idnumber = $idnumber; // set idnumber
+        $group->description = $term->name; // use academic session name as description
+        $group->enrolmentkey = '';
+        $group->timecreated = time();
+        $group->timemodified = time();
+        $group->id = $DB->insert_record('groups', $group);
+        return $group;
     }
 
     /**
@@ -680,6 +748,7 @@ EOF;
         return $localcourse;
     }
 
+    
     /**
      * Update or create a Moodle User based on an entity representing a user.
      *
@@ -1011,13 +1080,6 @@ EOF;
                 $this->add_metric('enrollment', 'update');
             }
         } else {
-            // $this->get_trace()->output(sprintf(
-            //     "Enroling user %s into %s from %d to %d",
-            //     $userentity->get('identifier'),
-            //     $instance->courseid,
-            //     $enroldata->timestart,
-            //     $enroldata->timeend
-            // ), 5);
             $this->get_plugin_instance()->enrol_user(
                 $instance,
                 $moodleuserid,
@@ -1040,14 +1102,6 @@ EOF;
             if ($ras) {
                 return;
             }
-            // if ($CFG->debugdeveloper) {
-            //     $this->get_trace()->output(
-            //         "Updating role assignment for " .
-            //         $userentity->get('identifier') .
-            //         " in {$instance->courseid}",
-            //         5);
-            // }
-            // asign role
             role_assign($moodleroleid, $moodleuserid, $context->id, $component, $itemid);
         }
 

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -85,4 +85,4 @@ $string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRo
 $string['settings_connection_oneroster_sync_agents'] = 'User Agents';
 $string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';
 $string['settings_connection_oneroster_sync_groups'] = 'Groups';
-$string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will synchronize the groups and group memberships.';
+$string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -84,3 +84,5 @@ $string['settings_connection_oneroster_caching'] = 'Caching';
 $string['settings_connection_oneroster_caching_desc'] = 'Enable caching of OneRoster data across different sync process to improve performance.';
 $string['settings_connection_oneroster_sync_agents'] = 'User Agents';
 $string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';
+$string['settings_connection_oneroster_sync_groups'] = 'Groups';
+$string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will synchronize the groups and group memberships.';

--- a/settings.php
+++ b/settings.php
@@ -292,6 +292,14 @@ if ($ADMIN->fulltree) {
         $availableschools[''] = get_string('none', 'admin');
     }
 
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_sync_groups',
+        get_string('settings_connection_oneroster_sync_groups', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_sync_groups_desc', 'enrol_oneroster'),
+        0,
+        $yesno
+    ));
+
     $settings->add(new admin_setting_configmultiselect(
         'enrol_oneroster/datasync_schools',
         get_string('settings_datasync_schools', 'enrol_oneroster'),

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024121602;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025010401;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-12-16';
+$plugin->release = '2025-01-04';
 $plugin->maturity = MATURITY_ALPHA;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024102901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2024121602;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2024-10-29';
+$plugin->release = '2024-12-16';
 $plugin->maturity = MATURITY_ALPHA;


### PR DESCRIPTION
This MR enables the usage of course groups. A student's enrollment may contain information about the term associated with it. This information may be used for creating course groups and move enrollments to these groups e.g. a class contains enrollments associated with two terms: fall and spring term of academic year 2024. Enabling group management will create two different groups and associate enrollments with that groups.