### PR TITLE
exclude inactive classes

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -210,14 +210,15 @@ trait oneroster_client {
         }
         
         $this->get_trace()->output("Completed synchronisation of Rostering information");
-        $this->get_trace()->output(sprintf("Entity\t\tCreate\tUpdate\tDelete"), 1);
+        $this->get_trace()->output(sprintf("Entity\t\tCreate\tUpdate\tExclude\tDelete"), 1);
         foreach ($this->get_metrics() as $thing => $actions) {
             $this->get_trace()->output(
                 sprintf(
-                    "Entity '%s'\t%d\t%d\t%d",
+                    "Entity '%s'\t%d\t%d\t%d\t%d",
                     $thing,
                     $actions['create'],
                     $actions['update'],
+                    $actions['exclude'],
                     $actions['delete']
                 ),
                 1

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -86,3 +86,5 @@ $string['settings_connection_oneroster_sync_agents'] = 'User Agents';
 $string['settings_connection_oneroster_sync_agents_desc'] = 'Enable synchronization of user agents. A user agent expresses the relationship between humans e.g. a student is being linked to its parents';
 $string['settings_connection_oneroster_sync_groups'] = 'Groups';
 $string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';
+$string['settings_connection_oneroster_exclude_inactive'] = 'Exclude inactive courses';
+$string['settings_connection_oneroster_exclude_inactive_desc'] = 'Exclude inactive courses from the synchronization process. This setting will only synchronize courses that are active in the OneRoster API.';

--- a/settings.php
+++ b/settings.php
@@ -300,6 +300,14 @@ if ($ADMIN->fulltree) {
         $yesno
     ));
 
+    $settings->add(new admin_setting_configselect(
+        'enrol_oneroster/oneroster_exclude_inactive',
+        get_string('settings_connection_oneroster_exclude_inactive', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_exclude_inactive_desc', 'enrol_oneroster'),
+        1,
+        $yesno
+    ));
+
     $settings->add(new admin_setting_configmultiselect(
         'enrol_oneroster/datasync_schools',
         get_string('settings_datasync_schools', 'enrol_oneroster'),

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025010401;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025010901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-04';
-$plugin->maturity = MATURITY_ALPHA;
+$plugin->release = '2025-01-09';
+$plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR closes #26 and excludes inactive courses while the sync process is validating course status and trying to create a new course.