### PR TITLE
Enable or disable enrolment method

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -628,25 +628,23 @@ EOF;
      */
     protected function ensure_course_enrolment_instance_exists(stdClass $course): void {
         global $DB;
-
-        if (array_key_exists($course->idnumber, $this->instances)) {
-            // The entry already exists in the cache.
-            return;
-        }
-
+        // try to get instance
         $instance = $DB->get_record('enrol', [
             'courseid' => $course->id,
             'enrol' => 'oneroster',
         ]);
-
+        // get status based on the visibility of the course
+        $status = $course->visible == false ? 1 : 0;
         if ($instance) {
             // A record exists, add it to the list.
             $this->instances[$course->idnumber] = $instance;
-
+            // enable or disable enrolment instance
+            $this->get_plugin_instance()->update_instance($instance, (object)[ 'status' => $status ]);
+            // and exit
             return;
         }
-
-        $enrolid = $this->get_plugin_instance()->add_instance($course);
+        // add instance
+        $enrolid = $this->get_plugin_instance()->add_instance($course, ['status' => $status ]);
         $this->instances[$course->idnumber] = $DB->get_record('enrol', ['id' => $enrolid]);
     }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025010901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025011001;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-09';
+$plugin->release = '2025-01-10';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR enables or disables `OneRoster` enrolment method based on the visibility of the given course. This feature is important for processes where courses are being replaced by other courses and class rosters are being merged into one e-learning course.