### PR TITLE
add user metadata settings and update user

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -788,6 +788,22 @@ EOF;
         $remoteuser->auth = $this->get_config_setting('newuser_auth');
         $remoteuser->confirmed = true;
 
+        $metadata = $entity->get('metadata');
+        if ($metadata) {
+            $department_map = get_config('enrol_oneroster', 'user_department_map');
+            if (empty($department_map) == FALSE) {
+                if (property_exists($metadata, $department_map)) {
+                    $remoteuser->department = $metadata->{$department_map};
+                }
+            }
+            $institution_map = get_config('enrol_oneroster', 'user_institution_map');
+            if (empty($institution_map) == FALSE) {
+                if (property_exists($metadata, $institution_map)) {
+                    $remoteuser->institution = $metadata->{$institution_map};
+                }
+            }
+        }
+
         if ($this->get_user_mapping($remoteuser->idnumber)) {
             $localuser = $this->update_existing_user($entity, $remoteuser);
         } else {

--- a/lang/en/enrol_oneroster.php
+++ b/lang/en/enrol_oneroster.php
@@ -88,3 +88,11 @@ $string['settings_connection_oneroster_sync_groups'] = 'Groups';
 $string['settings_connection_oneroster_sync_groups_desc'] = 'Enable synchronization of groups. A course may have one or more groups of students. This setting will try to synchronize groups and group memberships, using enrolment attributes like the term of an enrolment.';
 $string['settings_connection_oneroster_exclude_inactive'] = 'Exclude inactive courses';
 $string['settings_connection_oneroster_exclude_inactive_desc'] = 'Exclude inactive courses from the synchronization process. This setting will only synchronize courses that are active in the OneRoster API.';
+$string['settings_connection_oneroster_user_metadata'] = 'User metadata';
+$string['settings_connection_oneroster_user_metadata_desc'] = 'Define the metadata of a user that is going to be mapped to the user profile fields in Moodle.';
+$string['settings_connection_oneroster_user_department'] = 'department';
+$string['settings_connection_oneroster_user_department_desc'] = 'Define the attribute of a user that is going to be mapped to the department field in Moodle. e.g. Use field "alternateMatriculationNumber" provided by OneRoster producer and map it to "department" field in Moodle.';
+$string['settings_connection_oneroster_user_institution'] = 'institution';
+$string['settings_connection_oneroster_user_institution_desc'] = 'Define the attribute of a user that is going to be mapped to the institution field in Moodle. e.g. Use field "matriculationNumber" provided by OneRoster producer and map it to "institution" field in Moodle.';
+
+

--- a/settings.php
+++ b/settings.php
@@ -205,6 +205,29 @@ if ($ADMIN->fulltree) {
         )
     );
 
+    // User metadata.
+    $settings->add(new admin_setting_heading(
+        'enrol_oneroster/user_metadata',
+        new lang_string('settings_connection_oneroster_user_metadata', 'enrol_oneroster'),
+        new lang_string('settings_connection_oneroster_user_metadata_desc', 'enrol_oneroster')
+    ));
+
+    // User metadata - department.
+    $settings->add(new admin_setting_configtext(
+        'enrol_oneroster/user_department_map',
+        get_string('settings_connection_oneroster_user_department', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_user_department_desc', 'enrol_oneroster'),
+        ''
+    ));
+
+    // User metadata - department.
+    $settings->add(new admin_setting_configtext(
+        'enrol_oneroster/user_institution_map',
+        get_string('settings_connection_oneroster_user_institution', 'enrol_oneroster'),
+        get_string('settings_connection_oneroster_user_institution_desc', 'enrol_oneroster'),
+        ''
+    ));
+
 
     // Role mappings for the following One Roster roles:
     // - student;

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025011201;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025011703;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-12';
+$plugin->release = '2025-01-17';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR enables the synchronization of user attributes based on data provided by `metadata` attribute of OneRoster user. Moodle user fields `department` and `institution` can be mapped to metadata attributes and update local user information.

![image](https://github.com/user-attachments/assets/b17917b0-73f3-4b7d-a5ce-5891319a4bdc)
