### PR TITLE
use local course category instead of the given remote category

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -730,6 +730,10 @@ EOF;
         ]);
 
         if ($localcourse) {
+            // do not change category and use the existing one
+            if ($localcourse->category) {
+                $remotecourse->category = $localcourse->category;
+            }
             $update = false;
             foreach ((array) $remotecourse as $field => $value) {
                 if ($localcourse->{$field} != $value) {

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025011703;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025012701;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-17';
+$plugin->release = '2025-01-27';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR closes #24 and changes the operation which updates a local course forcing the usage of the existing category even if it has been already changed for the remote course. This improvement is important for managing courses and move them from category to category.