### PR TITLE
Force update existing user if user metadata have been changed

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -915,13 +915,17 @@ EOF;
         // The user exists, user_update_user works on user 'id', so fill that in.
         $remoteuser->id = $localuser->id;
 
-        if ($localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
-            // if ($CFG->debugdeveloper) {
-            //     $this->get_trace()->output(sprintf("Skipping update of existing user %s with id %s",
-            //         $localuser->username,
-            //         $localuser->id
-            //     ), 5);
-            // }
+        // a user should be updated if the remote user has been modified after the local user
+        // but sometimes we should update the user even if the remote user has not been modified
+        // for example, if the remote user has a different department or institution than the local user
+        // we should force update the local user
+        $force = FALSE;
+        if ((property_exists($remoteuser, 'department') && $remoteuser->department != $localuser->department) ||
+            (property_exists($remoteuser, 'institution') && $remoteuser->institution != $localuser->institution)) {
+            $force = TRUE;
+        }
+
+        if ($force == FALSE && $localuser->timemodified > converter::from_datetime_to_unix($entity->get('dateLastModified'))) {
             return $localuser;
         }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025012701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025012901;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-27';
+$plugin->release = '2025-01-29';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
The default operation of updating an existing user validates the date modified of the remote user against the last modified date of the local user. Sometimes it seems important to update the local user even if this check fails. When the remote service provides information like `department` or `institution` attributes of the local user, we should check and validate their state in local user record and force update it if they have been changed.