### PR TITLE
use enrolment terms and add enrolment groups

### DIFF
--- a/classes/local/entities/enrollment.php
+++ b/classes/local/entities/enrollment.php
@@ -187,4 +187,17 @@ class enrollment extends entity implements enrollment_representation {
         return null;
     }
 
+    public function get_enrolment_terms() {
+        $metadata = $this->get('metadata');
+        if (empty($metadata)) {
+            return [];
+        }
+        if (is_array($metadata->terms)) {
+            return array_map(function($term) {
+                return $this->container->get_entity_factory()->fetch_academic_session_by_id($term);
+            }, $metadata->terms);
+        }
+        return [];
+    }
+
 }

--- a/classes/local/interfaces/enrollment_representation.php
+++ b/classes/local/interfaces/enrollment_representation.php
@@ -64,4 +64,10 @@ interface enrollment_representation {
      * @return  stdClass
      */
     public function get_enrolment_term();
+    /**
+     * Get a collection of terms associated with the enrollment.
+     *
+     * @return  stdClass[]
+     */
+    public function get_enrolment_terms();
 }

--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -52,6 +52,7 @@ use enrol_oneroster\local\entities\org as org_entity;
 use enrol_oneroster\local\entities\school as school_entity;
 use enrol_oneroster\local\entities\user as user_entity;
 use enrol_oneroster\local\entities\term as term_entity;
+use enrol_oneroster\local\entities\academic_session as academic_session_entity;
 use moodle_url;
 use progress_trace;
 use stdClass;
@@ -481,6 +482,20 @@ EOF;
                                 groups_add_member($course_group, $localuserid, 'enrol_oneroster');
                             }
                         }
+                        // get extra enrolment terms
+                        $enrolment_terms = $enrollment->get_enrolment_terms();
+                        foreach ($enrolment_terms as $term) {
+                            // try to find if the current course has a group associated with the term
+                            $course_group = $this->create_course_group_from_term($localcourse, $term);
+                            // get remote user
+                            $userentity = $enrollment->get_user_entity();
+                            // find local user
+                            $localuserid = $this->get_user_mapping_for_user($userentity);
+                            if ($localuserid) {
+                                // add group membership
+                                groups_add_member($course_group, $localuserid, 'enrol_oneroster');
+                            }
+                        }
                     }
                 }
             }
@@ -547,10 +562,10 @@ EOF;
     /**
      * Create course group using the given academic session
      * @param \stdClass $course
-     * @param term_entity $term
+     * @param academic_session_entity $term
      * @return \stdClass
      */
-    protected function create_course_group_from_term(stdClass $course, term_entity $term): stdClass {
+    protected function create_course_group_from_term(stdClass $course, academic_session_entity $term): stdClass {
         global $DB;
         // if course groups are not enabled
         if (!is_array($course->groups)) {

--- a/version.php
+++ b/version.php
@@ -24,8 +24,15 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025012901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025081801;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
+$plugin->supported = [
+    400,
+    401,
+    402,
+    403,
+    404
+];
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-01-29';
+$plugin->release = '2025-08-18';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR implements the usage of enrolment terms  -`metadata.terms`: a collection of terms assigned to an enrollment e.g. a grading period- for creating course groups and assign students to them.