### PR TITLE
use semester or school year for filtering classes

### DIFF
--- a/classes/local/v1p1/oneroster_client.php
+++ b/classes/local/v1p1/oneroster_client.php
@@ -334,7 +334,28 @@ EOF;
         // select active academic session
         $academic_session = get_config('enrol_oneroster', 'datasync_academic_session');
         if ($academic_session) {
-            $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+            // get academic session
+            $academic_session_filter = new filter();
+            $academic_session_filter->add_filter('sourcedId', $academic_session, '=');
+            $academic_sessions = $this->get_container()->get_collection_factory()->get_academic_sessions([], $academic_session_filter);
+            foreach ($academic_sessions as $session) {
+                // exit the loop to get session
+                break;
+            }
+            if ($session instanceof academic_session_entity) {
+               // get academic session type
+                $sessiontype = $session->get('type');
+                if ($sessiontype == 'schoolYear') {
+                    // if school year, include semesters (filtering by parent)
+                    $classfilter->add_filter('terms.parent', $session->get('sourcedId'), '=');
+                } else {
+                    // otherwise, filter by the exact term
+                    $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+                }
+            } else {
+                // if no session found, filter by the exact term
+                $classfilter->add_filter('terms.sourcedId', $academic_session, '=');
+            }
         }
 
         $this->get_trace()->output("Fetching class data", 3);
@@ -1376,7 +1397,7 @@ EOF;
      */
     public function fetch_academic_session_list(): Iterable {
         return $this->get_container()->get_collection_factory()->get_academic_sessions(array(
-            'sort' => 'schoolYear',
+            'sort' => 'schoolYear,type',
             'orderBy' => 'asc'
         ));
     }

--- a/testconnection.php
+++ b/testconnection.php
@@ -75,7 +75,7 @@ $academic_sessions = $client->fetch_academic_session_list();
 $found_sessions = [];
 foreach ($academic_sessions as $academic_session) {
     // get only semesters
-    if ($academic_session->get('type') == 'semester') {
+    if ($academic_session->get('type') == 'semester' || $academic_session->get('type') == 'schoolYear') {
         $found_sessions[$academic_session->get('sourcedId')] = $academic_session->get('title');
     }
 }

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025081901;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025090902;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->supported = [
     405,
     500
 ];
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-08-19';
+$plugin->release = '2025-09-09';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR updates OneRoster client configuration to allow the usage of an school year as the active academic session. This operation is important when we are selecting to synchronize classes of a whole school year -including all semesters- or accepting web hooks for any semester of a specific school year.