### PR TITLE
remove invalid filter exception

### DIFF
--- a/classes/local/v1p1/filter.php
+++ b/classes/local/v1p1/filter.php
@@ -53,9 +53,9 @@ class filter extends filter_base {
      * @return  filter_interface
      */
     public function add_filter(string $field, string $value, string $predicate = '='): filter_interface {
-        if (count($this->filters) >= 2) {
-            throw new \InvalidArgumentException("You may only specify two filters");
-        }
+        // if (count($this->filters) >= 2) {
+        //     throw new \InvalidArgumentException("You may only specify two filters");
+        // }
 
         $this->filters[] = sprintf(
             "%s%s'%s'",

--- a/version.php
+++ b/version.php
@@ -24,12 +24,12 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2025100701;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2025101501;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2019052000;        // Requires this Moodle version.
 $plugin->supported = [
     405,
     500
 ];
 $plugin->component = 'enrol_oneroster'; // Full name of the plugin (used for diagnostics).
-$plugin->release = '2025-10-07';
+$plugin->release = '2025-10-15';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This PR removes the exception "You may only specify two filters" when a filter contains more than 2 filter expressions. This operation -of suppporting multiple filters- has been already valid.